### PR TITLE
Fix inserBefore error

### DIFF
--- a/live-form-validation.js
+++ b/live-form-validation.js
@@ -302,8 +302,10 @@ LiveForm.getMessageElement = function(el) {
 		}
 
 		var parentEl = this.getMessageParent(el);
-		if (parentEl) {
+		if (parentEl === el.parentNode) {
 			parentEl.insertBefore(messageEl, el.nextSibling);
+		} else if(parentEl) {
+			parentEl.append(messageEl);
 		}
 	}
 


### PR DESCRIPTION
Narazil jsem na stejný problém jako se řeší v tomto ISSUE https://github.com/contributte/live-form-validation/issues/48

Toto by to mělo fixovat. Problém je že metoda ``getMessageParent`` může vracet né přímého rodiče elementru. Když k tomu dojde (například u checkboxu, který je vložen do tagu label) tak volání ``parentEl.insertBefore(messageEl, el.nextSibling);``  selže protože ``el.nextSibling`` není přímým potomkem parentEl.

Můj fix spočívá v rozpoznání tohoto případu a vložení chybové zprávy na konec rodičovského elementu pomocí metody append.