### PR TITLE
Fix novalidate error

### DIFF
--- a/live-form-validation.js
+++ b/live-form-validation.js
@@ -1123,6 +1123,10 @@ Nette.toggle = function(id, visible, srcElement) {
  * Setup handlers.
  */
 Nette.initForm = function(form) {
+	if (form.noValidate) {
+		return;
+	}
+
 	form.noValidate = 'novalidate';
 
 	// LiveForm: addition


### PR DESCRIPTION
Nějak se z originální knihovny vytratila podmínka na vypnutí validace, když má formulář nastavený atribut novalidate viz. https://github.com/nette/forms/blob/master/src/assets/netteForms.js#L671