### PR TITLE
Hotfix Nette.getValue - elem.value can be a number

### DIFF
--- a/live-form-validation.js
+++ b/live-form-validation.js
@@ -514,7 +514,7 @@ Nette.getValue = function(elem) {
 		return elem.value.replace("\r", '');
 
 	} else {
-		return elem.value.replace("\r", '').replace(/^\s+|\s+$/g, '');
+		return elem.value.toString().replace("\r", '').replace(/^\s+|\s+$/g, '');
 	}
 };
 


### PR DESCRIPTION
Hotfix for Nette.getValue function - elem.value can sometimes be the number type.