### PR TITLE
Fix for LiveForm.getMessageElement() - parentNode.append IE11 issue

### DIFF
--- a/live-form-validation.js
+++ b/live-form-validation.js
@@ -305,7 +305,7 @@ LiveForm.getMessageElement = function(el) {
 		if (parentEl === el.parentNode) {
 			parentEl.insertBefore(messageEl, el.nextSibling);
 		} else if(parentEl) {
-			parentEl.append(messageEl);
+			typeof parentEl.append === 'function' ? parentEl.append(messageEl) : parentEl.appendChild(messageEl);
 		}
 	}
 


### PR DESCRIPTION
ParentNode.append() is not supported in IE11 -> created fallback with obsolete ParentNode.appendChild() (https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/append)