### PR TITLE
Fix number validator empty values

### DIFF
--- a/live-form-validation.js
+++ b/live-form-validation.js
@@ -935,7 +935,7 @@ Nette.validators = {
 		if (elem.type === 'number' && elem.validity.badInput) {
 			return false;
 		}
-		return (/^-?[0-9]+$/).test(val);
+		return (/^(-?[0-9]+)?$/).test(val);
 	},
 
 	'float': function(elem, arg, val, value) {
@@ -943,7 +943,7 @@ Nette.validators = {
 			return false;
 		}
 		val = val.replace(' ', '').replace(',', '.');
-		if ((/^-?[0-9]*[.,]?[0-9]+$/).test(val)) {
+		if ((/^(-?[0-9]*[.,]?[0-9]+)?$/).test(val)) {
 			value.value = val;
 			return true;
 		}


### PR DESCRIPTION
According to addInteger method in Nette\Forms\Container it seems that integer input is supposed to be nullable and therefore empty value should be valid input for integer (assuming also for float).

https://github.com/nette/forms/blob/35f9b84c0245640cca2c6aa5544d0de4bb06a9d8/src/Forms/Container.php#L300