### PR TITLE
image/webp - Form:Image rule

### DIFF
--- a/live-form-validation.js
+++ b/live-form-validation.js
@@ -1052,7 +1052,7 @@
             if (window.FileList && val instanceof window.FileList) {
                 for (var i = 0; i < val.length; i++) {
                     var type = val[i].type;
-                    if (type && type !== 'image/gif' && type !== 'image/png' && type !== 'image/jpeg') {
+                    if (type && type !== 'image/gif' && type !== 'image/png' && type !== 'image/jpeg' && type !== 'image/webp') {
                         return false;
                     }
                 }


### PR DESCRIPTION
`->addRule(Form::IMAGE)` Nova verzia nette validatora podporuje aj  `image/webp`. live-form-validator ale pri pokuse o upload webp obrazka hlasi chybu `The uploaded file must be image in format JPEG, GIF, PNG or WebP.`